### PR TITLE
Make code and name error properties writable

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -11,6 +11,8 @@
 const kCode = Symbol('code');
 const messages = new Map();
 
+const { defineProperty } = Object
+
 // Lazily loaded
 var util = null;
 
@@ -18,11 +20,36 @@ function makeNodeError(Base) {
   return class NodeError extends Base {
     constructor(key, ...args) {
       super(message(key, args));
-      this[kCode] = this.code = key;
-      Object.defineProperty(this, 'name', {
+      defineProperty(this, kCode, {
         configurable: true,
         enumerable: false,
-        value: `${super.name} [${this[kCode]}]`,
+        value: key,
+        writable: true
+      });
+    }
+
+    get name() {
+      return `${super.name} [${this[kCode]}]`;
+    }
+
+    set name(value) {
+      defineProperty(this, 'name', {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true
+      });
+    }
+
+    get code() {
+      return this[kCode];
+    }
+
+    set code(value) {
+      defineProperty(this, 'code', {
+        configurable: true,
+        enumerable: true,
+        value,
         writable: true
       });
     }

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -291,15 +291,19 @@ assert.strictEqual(
 {
   const myError = new errors.Error('ERR_TLS_HANDSHAKE_TIMEOUT');
   assert.strictEqual(myError.code, 'ERR_TLS_HANDSHAKE_TIMEOUT');
+  assert.strictEqual(myError.hasOwnProperty('code'), false);
+  assert.strictEqual(myError.hasOwnProperty('name'), false);
+  assert.deepEqual(Object.keys(myError), []);
   const initialName = myError.name;
   myError.code = 'FHQWHGADS';
   assert.strictEqual(myError.code, 'FHQWHGADS');
   assert.strictEqual(myError.name, initialName);
+  assert.deepEqual(Object.keys(myError), ['code']);
   assert.ok(myError.name.includes('ERR_TLS_HANDSHAKE_TIMEOUT'));
   assert.ok(!myError.name.includes('FHQWHGADS'));
 }
 
-// Test that `name` and `message` are mutable and that changing them alters 
+// Test that `name` and `message` are mutable and that changing them alters
 // `toString()` but not `console.log()` results, which is the behavior of
 // `Error` objects in the browser.
 {


### PR DESCRIPTION
Make “code” and “name” error properties settable while keeping them non-own properties by default and making the `kCode` symbol non-enumerable so it doesn't show up in `console.log`'s.